### PR TITLE
issure-54-storage-contract-api

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -39,6 +39,7 @@ func (a *apiV1) RegisterRoutes(e *echo.Echo) {
 
 	ConfigureStatusRouter(apiGroup)
 	a.ConfigureAddressesRouter(apiGroup)
+	a.ConfigureStorageContractRouter(apiGroup)
 }
 
 func NewApiV1(db *gorm.DB) *apiV1 {

--- a/api/v1/storage-contract.go
+++ b/api/v1/storage-contract.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/data-preservation-programs/spade-tenant/db"
+	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -55,7 +56,9 @@ func (a *apiV1) handleSetStorageContract(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, err.Error()))
 	}
 
-	if len(addressedStorageContract.Cid) == 0 {
+	_, err = cid.Decode(addressedStorageContract.Cid)
+
+	if err != nil || len(addressedStorageContract.Cid) == 0 {
 		return c.JSON(http.StatusNotImplemented, CreateErrorResponseEnvelope(c, http.StatusNotImplemented, "StorageContract is not currently supported. Please pass in a CID."))
 	}
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature to the API that allows users to set and get storage contracts. The storage contract is associated with a tenant and can be updated via a POST request and retrieved via a GET request.
> 
> ## What changed
> Two new routes have been added to the API: `POST /storage-contract` and `GET /storage-contract`. 
> 
> The `POST /storage-contract` route allows users to set a new storage contract for a tenant. The request body must contain a JSON object with a `cid` field representing the storage contract. If the `cid` is valid, it is saved to the database and associated with the tenant.
> 
> The `GET /storage-contract` route allows users to retrieve the current storage contract for a tenant. The response body contains a JSON object with a `cid` field representing the storage contract.
> 
> ## How to test
> To test the `POST /storage-contract` route, send a POST request to `/storage-contract` with a JSON body containing a `cid` field. The `cid` should be a valid CID. The response should be a JSON object with a `cid` field representing the storage contract.
> 
> To test the `GET /storage-contract` route, send a GET request to `/storage-contract`. The response should be a JSON object with a `cid` field representing the storage contract.
> 
> ## Why make this change
> This change allows users to manage storage contracts for tenants. This is a necessary feature for any data storage application, as it allows users to control where and how their data is stored.
</details>