### PR TITLE
issue-54-settings-api

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -41,6 +41,7 @@ func (a *apiV1) RegisterRoutes(e *echo.Echo) {
 	a.ConfigureAddressesRouter(apiGroup)
 	a.ConfigureStorageContractRouter(apiGroup)
 	a.ConfigureSPRouter(apiGroup)
+	a.ConfigureSettingsRouter(apiGroup)
 }
 
 func NewApiV1(db *gorm.DB) *apiV1 {

--- a/api/v1/settings.go
+++ b/api/v1/settings.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/data-preservation-programs/spade-tenant/db"
 	"github.com/labstack/echo/v4"
 )
 
@@ -12,25 +14,56 @@ type Settings struct {
 	MaxInFlightGiB uint `json:"max_in_flight_gib"`
 }
 
-// handleGetSettings godoc
-//
-//		@Summary		Apply new Tenant Settings
-//		@Security apiKey
-//	  @Param 			settings body Settings true "New settings to apply"
-//		@Produce		json
-//		@Success		200	{object}	ResponseEnvelope{response=Settings}
-//		@Router			/settings [post]
-func handleGetSettings(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{})
+func (a *apiV1) ConfigureSettingsRouter(e *echo.Group) {
+	g := e.Group("/settings")
+	g.POST("", a.handleSetSettings)
+	g.GET("", a.handleGetSettings)
 }
 
 // handleSetSettings godoc
 //
 //	@Summary		Get the currently active Tenant Settings
-//	@Security apiKey
+//	@Security		apiKey
 //	@Produce		json
 //	@Success		200	{object}	ResponseEnvelope{response=Settings}
 //	@Router			/settings [get]
-func handleSetSettings(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{})
+func (a *apiV1) handleGetSettings(c echo.Context) error {
+	var tenant db.Tenant
+	tenant.TenantID = db.ID(GetTenantContext(c).TenantID)
+	res := a.db.Model(&db.Tenant{}).Find(&tenant)
+
+	if res.Error != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, res.Error.Error()))
+	}
+
+	return c.JSON(http.StatusOK, CreateSuccessResponseEnvelope(c, tenant.TenantSettings))
+}
+
+// handleGetSettings godoc
+//
+//	@Summary		Apply new Tenant Settings
+//	@Security		apiKey
+//	@Param			settings body Settings true "New settings to apply"
+//	@Produce		json
+//	@Success		200	{object}	ResponseEnvelope{response=Settings}
+//	@Router			/settings [post]
+func (a *apiV1) handleSetSettings(c echo.Context) error {
+	var settings Settings
+
+	err := json.NewDecoder(c.Request().Body).Decode(&settings)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, err.Error()))
+	}
+
+	var tenant db.Tenant
+	tenant.TenantID = db.ID(GetTenantContext(c).TenantID)
+
+	res := a.db.Model(&tenant).UpdateColumn("tenant_settings", &settings)
+
+	if res.Error != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, CreateSuccessResponseEnvelope(c, "Updated Settings associated with the tenant"))
 }


### PR DESCRIPTION
Implementation of the settings api.  

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces the ability to get and set tenant settings in the API. It adds a new route to the API for handling settings and implements the corresponding handlers for getting and setting the settings.
> 
> ## What changed
> Two new handlers `handleGetSettings` and `handleSetSettings` were added to the `apiV1` struct in `api/v1/api.go`. These handlers are responsible for getting and setting the tenant settings respectively. 
> 
> The `handleGetSettings` handler retrieves the tenant settings from the database and returns them in the response. The `handleSetSettings` handler takes a `Settings` object from the request body, updates the tenant settings in the database, and returns a success message.
> 
> A new route `/settings` was added to the API in the `RegisterRoutes` function of the `apiV1` struct. This route is configured with the new handlers for getting and setting the settings.
> 
> ## How to test
> To test these changes, you can use a tool like Postman or cURL to send GET and POST requests to the `/settings` endpoint of the API. 
> 
> For the GET request, you should receive a response containing the current tenant settings. For the POST request, you should send a `Settings` object in the request body. The response should be a success message indicating that the settings were updated.
> 
> ## Why make this change
> This change is necessary to allow users to view and modify the settings associated with a tenant. This can be useful for managing resource usage and other configuration options for tenants.
</details>