### PR TITLE
issue-54-sp-eliigibility-criteria-api

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -42,6 +42,7 @@ func (a *apiV1) RegisterRoutes(e *echo.Echo) {
 	a.ConfigureStorageContractRouter(apiGroup)
 	a.ConfigureSPRouter(apiGroup)
 	a.ConfigureSettingsRouter(apiGroup)
+	a.ConfigureSpEligibilityCriteriaRouter(apiGroup)
 }
 
 func NewApiV1(db *gorm.DB) *apiV1 {

--- a/api/v1/sp-eligibility-criteria.go
+++ b/api/v1/sp-eligibility-criteria.go
@@ -1,41 +1,98 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/data-preservation-programs/spade-tenant/db"
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
-type EligibilityCriteria struct {
-	Clauses []EligibilityClause `json:"clauses"`
+func (a *apiV1) ConfigureSpEligibilityCriteriaRouter(e *echo.Group) {
+	g := e.Group("/sp")
+	g.POST("/eligibility-criteria", a.handleSetSpEligibilityCriteria)
+	g.GET("/eligibility-criteria", a.handleGetSpEligibilityCriteria)
+	g.DELETE("/eligibility-criteria/attribute/:attribute", a.handleDeleteSpEligibilityCriteria)
 }
 
-type EligibilityClause struct {
-	Attribute string `json:"attribute"`
-	Operator  string `json:"operator"`
-
-	Value interface{} `json:"value"` // TODO: type - either []string or string
+type TenantSPEligibilityClausesResponse struct {
+	ClauseAttribute string                `json:"attribute"`
+	ClauseOperator  db.ComparisonOperator `json:"operator"`
+	ClauseValue     string                `json:"value"`
 }
 
 // handleSetSpEligibilityCriteria godoc
 //
-//		@Summary		Set sp eligibility criteria
-//		@Security apiKey
-//	  @Param 			elibility_criteria body EligibilityCriteria true "New eligibility criteria to update to"
-//		@Produce		json
-//		@Success		200	{object}	ResponseEnvelope{response=EligibilityCriteria}
-//		@Router			/sp/eligibility-criteria [post]
-func handleSetSpEligibilityCriteria(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{})
+//	@Summary		Set sp eligibility criteria
+//	@Security		apiKey
+//	@Param			eligibility_criteria body EligibilityCriteria true "New eligibility criteria to update to"
+//	@Produce		json
+//	@Success		200	{object}	ResponseEnvelope{response=EligibilityCriteria}
+//	@Router			/sp/eligibility-criteria [post]
+//
+
+func (a *apiV1) handleSetSpEligibilityCriteria(c echo.Context) error {
+	var eligibilityCriteria []db.TenantSPEligibilityClauses
+	err := json.NewDecoder(c.Request().Body).Decode(&eligibilityCriteria)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, err.Error()))
+	}
+
+	err = a.db.Transaction(func(tx *gorm.DB) error {
+		for _, eligibilityClause := range eligibilityCriteria {
+			eligibilityClause.TenantID = db.ID(GetTenantContext(c).TenantID)
+			res := tx.Save(&eligibilityClause)
+			if res.Error != nil {
+				return res.Error
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, CreateSuccessResponseEnvelope(c, "Updated Eligibility clauses associated with the tenant"))
 }
 
 // handleGetSpEligibilityCriteria godoc
 //
 //	@Summary		Get sp eligibility criteria
-//	@Security apiKey
+//	@Security		apiKey
 //	@Produce		json
 //	@Success		200	{object}	ResponseEnvelope{response=EligibilityCriteria}
 //	@Router			/sp/eligibility-criteria [get]
-func handleGetSpEligibilityCriteria(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, map[string]string{})
+func (a *apiV1) handleGetSpEligibilityCriteria(c echo.Context) error {
+	var eligibilityCriteria []TenantSPEligibilityClausesResponse
+	var clause db.TenantSPEligibilityClauses
+	clause.TenantID = db.ID(GetTenantContext(c).TenantID)
+
+	res := a.db.Model(&db.TenantSPEligibilityClauses{}).Find(&eligibilityCriteria)
+
+	if res.Error != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, res.Error.Error()))
+	}
+
+	return c.JSON(http.StatusOK, CreateSuccessResponseEnvelope(c, eligibilityCriteria))
+}
+
+// handleDeleteSpEligibilityCriteria godoc
+//
+//	@Summary		Get sp eligibility criteria
+//	@Security		apiKey
+//	@Produce		json
+//	@Success		200	{object}	ResponseEnvelope{response=EligibilityCriteria}
+//	@Router			/sp/eligibility-criteria/attribute/:attribute [delete]
+func (a *apiV1) handleDeleteSpEligibilityCriteria(c echo.Context) error {
+	res := a.db.Find(&db.TenantSPEligibilityClauses{TenantID: db.ID(GetTenantContext(c).TenantID), ClauseAttribute: c.Param("attribute")})
+
+	if res.Error != nil {
+		return c.JSON(http.StatusInternalServerError, CreateErrorResponseEnvelope(c, http.StatusInternalServerError, res.Error.Error()))
+	}
+
+	return c.JSON(http.StatusOK, CreateSuccessResponseEnvelope(c, "Deleted attribute: "+c.Param("attribute")))
 }

--- a/db/schema.go
+++ b/db/schema.go
@@ -105,6 +105,7 @@ type TenantSPEligibilityClauses struct {
 	ClauseOperator  ComparisonOperator `json:"operator" gorm:"type:comparison_operator;not null"`
 	ClauseValue     string             `json:"value" gorm:"not null"`
 }
+
 type Collection struct {
 	ModelBase
 	CollectionID          uuid.UUID    `json:"collection_id" gorm:"type:uuid;primaryKey"`


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces changes to the API and database schema to support the configuration of Service Provider (SP) eligibility criteria. It includes the addition of new routes to get and set SP eligibility criteria, as well as the necessary handlers and database interactions.
> 
> ## What changed
> - A new route was added to the API to configure the SP eligibility criteria router.
> - Two new handlers were added: `handleSetSpEligibilityCriteria` and `handleGetSpEligibilityCriteria`. These handlers interact with the database to set and get the SP eligibility criteria respectively.
> - The database schema was updated to include a new `TenantSPEligibilityClauses` struct, which represents the eligibility criteria for a tenant.
> 
> ## How to test
> 1. Pull the changes from this PR and run the application.
> 2. Use a tool like Postman to send a POST request to the `/sp/eligibility-criteria` endpoint with the eligibility criteria in the request body.
> 3. Verify that the eligibility criteria are correctly stored in the database.
> 4. Send a GET request to the `/sp/eligibility-criteria` endpoint and verify that the correct eligibility criteria are returned.
> 
> ## Why make this change
> This change is necessary to allow the configuration of SP eligibility criteria. This is a key feature of the application, as it allows tenants to specify the criteria that a service provider must meet in order to be eligible to provide a service.
</details>